### PR TITLE
Fix mardown format and add build badge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@ _Any italic text should be deleted from the final Pull Request text, including t
 
 # Description
 
-_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._
+_Please include a summary of the change and which issue is fixed. Please also include relevant
+motivation and context. List any dependencies that are required for this change._
 
 Fixes # (issue)
 
@@ -12,12 +13,14 @@ _Please delete options that are not relevant._
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
+      expected)
 - [ ] Documentation (update or new)
 
 # How Has This Been Tested?
 
-_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can
+reproduce. Please also list any relevant details for your test configuration_
 
 ## Testing Checklist:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# documentation
+# Documentation
+
+[![CI](https://github.com/thoth-tech/documentation/actions/workflows/ci.yml/badge.svg)](https://github.com/thoth-tech/documentation/actions/workflows/ci.yml)
+[![Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io/)
 
 Add all of your Research, Meeting Agendas and everything project related.
+
+## Contributing
+
+Please see the [contribution guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
# Description

- Fix markdown format issues that are breaking the CI build
- Add build badge and contributing references to README

<img width="574" alt="Screen Shot 2022-04-21 at 5 46 38 pm" src="https://user-images.githubusercontent.com/756722/164405565-e20ab88c-ab69-4723-ad48-b037937c7012.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (update or new)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
