### PR TITLE
feat: add Vale VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"],
+  "recommendations": ["errata-ai.vale-server", "esbenp.prettier-vscode"],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
# Description

This PR add Vale to the list of suggested VSCode extensions. If the user does not have the Vale extension installed, they will be prompted to download it. This change was missed as part of https://github.com/thoth-tech/documentation/pull/60.

<img width="1141" alt="Screen Shot 2022-05-16 at 10 02 12 pm" src="https://user-images.githubusercontent.com/756722/168588350-5589878d-234b-464e-b449-02ce13e24f8f.png">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
