### PR TITLE
docs: Initialise srs documents for modules

### DIFF
--- a/docs/Splashkit/Modules/Data Analytics/Software_Requirements_Specification.md
+++ b/docs/Splashkit/Modules/Data Analytics/Software_Requirements_Specification.md
@@ -1,0 +1,27 @@
+# Software Requirement Specification (SRS) Document Template
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+### 1.2 Intended Audience
+
+### 1.3 Intended Use
+
+### 1.4 Scope
+
+### 1.5 Definitions and Acronyms
+
+## Overall Description
+
+### 2.1 User Needs
+
+### 2.2 Assumptions and Dependencies
+
+## System Features and Requirements
+
+### 3.1 Functional Requirements
+
+### 3.2 External Interface Requirements
+
+### 3.3 Nonfunctional Requirements

--- a/docs/Splashkit/Modules/Physics/Software_Requirements_Specification.md
+++ b/docs/Splashkit/Modules/Physics/Software_Requirements_Specification.md
@@ -1,0 +1,27 @@
+# Software Requirement Specification (SRS) Document Template
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+### 1.2 Intended Audience
+
+### 1.3 Intended Use
+
+### 1.4 Scope
+
+### 1.5 Definitions and Acronyms
+
+## Overall Description
+
+### 2.1 User Needs
+
+### 2.2 Assumptions and Dependencies
+
+## System Features and Requirements
+
+### 3.1 Functional Requirements
+
+### 3.2 External Interface Requirements
+
+### 3.3 Nonfunctional Requirements


### PR DESCRIPTION
Added files containing Thoth Tech SRS template for physics and data analytics modules

# Description

The Software Requirement Specifications template from the Thoth Tech handbook has been added to the documentation repository under the Physics and the Data Analytics modules. These will be added to shortly to fill out each section.

Fixes # (issue)

## Type of change

- [ ] Documentation (new)

# How Has This Been Tested?

N/A

## Testing Checklist:

- [N/A ] Tested in latest Chrome
- [N/A ] Tested in latest Safari
- [N/A ] Tested in latest Firefox

# Checklist:

- [ Y ] My code follows the style guidelines of this project
- [ Y ] I have performed a self-review of my own code
- [ Y ] I have commented my code in hard-to-understand areas
- [ Y ] I have made corresponding changes to the documentation
- [ Y ] My changes generate no new warnings
- [ Y ] I have requested a review from @Zephreo and @Alex-MobileApps  on the Pull Request
