### PR TITLE
FIX: Add Vale exceptions for Figma and Trello

### DIFF
--- a/docs/.vale/thothtech/spelling-exceptions.txt
+++ b/docs/.vale/thothtech/spelling-exceptions.txt
@@ -1,0 +1,2 @@
+trello
+figma


### PR DESCRIPTION
# Description

Vale (the linter) currently counts "Figma" and "Trello" as errors. These are products that require proper noun spelling and will be referenced in the documentation of the Task View and Submission Redesign project, so this pull request adds both "Figma" and "Trello" to the spelling-exceptions.txt file (a line per entry, case-insenitive exceptions).

## Type of change

- [ x ] Documentation (update or new)

# How Has This Been Tested?

I ensured that, after adding these to the spelling-exceptions.txt list, Vale no longer picked these up as linting errors that break the standards and conventions enforced by Thoth Tech via Vale.

Edit: However, the automated build process determines the use of "Figma" and "Trello" in the very spelling-exceptions.txt file is a violation of the linting rules. That is the reason for the check failures on this pull request.

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings
- [ x ] I have requested a review from Shaine Christmas, Matthew Paul Fletcher on the Pull Request
