### PR TITLE
Revert "FIX: Add Vale exceptions for Figma and Trello"

### DIFF
--- a/docs/.vale/thothtech/spelling-exceptions.txt
+++ b/docs/.vale/thothtech/spelling-exceptions.txt
@@ -1,2 +1,0 @@
-trello
-figma


### PR DESCRIPTION
Reverts thoth-tech/documentation#130

I was incorrect to make this pull request when I did. I misunderstood the situation and thought that this pull request was failing because of Vale, but it was failing because of linelint and an EOF violation. This pull request needs to be reverted, then I will restore the vale/trello-figma-exception branch and ammend the EOF violation, then I will submit a new pull request to properly add these exceptions into Vale.

I apologise for the mistake. I should have investigated it more thoroughly before coming to a conclusion.