### PR TITLE
docs:Add Spike Templates

### DIFF
--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,16 +1,17 @@
 # Spike Outcomes
 
 ==================
-**Spike:** Spike_No
 
-**Title:** Spike_Title
+## **Spike:** Spike_No
 
-**Author:** John Doe, john.doe@example.com
+## **Title:** Spike_Title
+
+## **Author:** John Doe, john.doe@example.com
 
 ## Goals / Deliverables
 
-_#### Summarise from the spike plan goal_
-_#### Besides this report, what else was created ie UML, code, reports_
+Summarise from the spike plan goal_
+Besides this report, what else was created ie UML, code, reports_
 
 - Code see /spikes/spike04/
 - Short Report titled “IDE Comparison”
@@ -18,7 +19,7 @@ _#### Besides this report, what else was created ie UML, code, reports_
 
 ## Technologies, Tools, and Resources used
 
-_#### List of information needed by someone trying to reproduce this work_
+List of information needed by someone trying to reproduce this work_
 
 - Internet Browser; Google Chrome, FireFox, Safari
 - Programming Languages:
@@ -30,13 +31,13 @@ _#### List of information needed by someone trying to reproduce this work_
 
 ## Tasks undertaken
 
-#### List key tasks likely to help another developer
+### List key tasks likely to help another developer
 
 - ...
 
 ## What we found out
 
-#### Describe (sentences), + graphs/screenshots/outcomes as needed
+### Describe (sentences), + graphs/screenshots/outcomes as needed
 
 ## Open issues/risks _[Optional – remove heading/section if not used!]_
 

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -10,15 +10,15 @@
 
 ## Goals / Deliverables
 
-Summarise from the spike plan goal_
-Besides this report, what else was created ie UML, code, reports_
+Summarise from the spike plan goal*
+Besides this report, what else was created ie UML, code, reports*
 
 - Code see /spikes/spike04/
 - Short Report titled “IDE Comparison”
 
 ## Technologies, Tools, and Resources used
 
-List of information needed by someone trying to reproduce this work_
+List of information needed by someone trying to reproduce this work\_
 
 - Internet Browser; Google Chroame, FireFox, Safari
 - Programming Languages:
@@ -38,18 +38,18 @@ List of information needed by someone trying to reproduce this work_
 
 ### Describe (sentences), + graphs/screenshots/outcomes as needed
 
-## Open issues/risks _[Optional – remove heading/section if not used!]_
+## Open issues/risks *[Optional – remove heading/section if not used!]*
 
-_#### List out the issues and risks that you have been unable to resolve at the
+*#### List out the issues and risks that you have been unable to resolve at the
  end of the spike. You may have uncovered a whole range of new risks as well.
- Make notes to help the team manage and respond._
+ Make notes to help the team manage and respond.*
 
 - e.g. Risk xyz (new)
 
-## Recommendations _[Optional – remove heading/section if not used!]_
+## Recommendations *[Optional – remove heading/section if not used!]*
 
-_### Often based on any open issues/risks Identified. You may state that another
+*### Often based on any open issues/risks Identified. You may state that another
  spike is required for the team to resolve new issues identified (or) indicate
- that this spike has increased the teams confidence in XYZ and should move on._
+ that this spike has increased the teams confidence in XYZ and should move on.*
 
 - e.g. Recommendation X:

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -15,17 +15,16 @@ Besides this report, what else was created ie UML, code, reports_
 
 - Code see /spikes/spike04/
 - Short Report titled “IDE Comparison”
-- …
 
 ## Technologies, Tools, and Resources used
 
 List of information needed by someone trying to reproduce this work_
 
-- Internet Browser; Google Chrome, FireFox, Safari
+- Internet Browser; Google Chroame, FireFox, Safari
 - Programming Languages:
-  - Ruby
+- Ruby
 - Programming Libraries:
-  - Minitest
+- Minitest
 - Text Editor: VsCode
 - Terminal
 

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,4 +1,4 @@
-# Spike Outcomes
+# **Spike Outcomes
 
 ==================
 
@@ -18,7 +18,7 @@ Besides this report, what else was created ie UML, code, reports*
 
 ## Technologies, Tools, and Resources used
 
-List of information needed by someone trying to reproduce this work\_
+List of information needed by someone trying to reproduce this work\
 
 - Internet Browser; Google Chroame, FireFox, Safari
 - Programming Languages:
@@ -53,3 +53,4 @@ spike is required for the team to resolve new issues identified (or) indicate
 that this spike has increased the teams confidence in XYZ and should move on.*
 
 - e.g. Recommendation X:
+**

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,4 +1,4 @@
-# **Spike Outcomes
+# \*\*Spike Outcomes
 
 ==================
 
@@ -10,8 +10,8 @@
 
 ## Goals / Deliverables
 
-Summarise from the spike plan goal*
-Besides this report, what else was created ie UML, code, reports*
+Summarise from the spike plan goal* Besides this report, what else was created ie UML, code,
+reports*
 
 - Code see /spikes/spike04/
 - Short Report titled “IDE Comparison”
@@ -38,19 +38,17 @@ List key tasks likely to help another developer
 
 Describe (sentences), + graphs/screenshots/outcomes as needed
 
-## Open issues/risks *[Optional – remove heading/section if not used!]*
+## Open issues/risks _[Optional – remove heading/section if not used!]_
 
-List out the issues and risks that you have been unable to resolve at the
-end of the spike. You may have uncovered a whole range of new risks as well.
-Make notes to help the team manage and respond.*
+List out the issues and risks that you have been unable to resolve at the end of the spike. You may
+have uncovered a whole range of new risks as well. Make notes to help the team manage and respond.\*
 
 - e.g. Risk xyz (new)
 
-## Recommendations *[Optional – remove heading/section if not used!]*
+## Recommendations _[Optional – remove heading/section if not used!]_
 
-Often based on any open issues/risks Identified. You may state that another
-spike is required for the team to resolve new issues identified (or) indicate
-that this spike has increased the teams confidence in XYZ and should move on.*
+Often based on any open issues/risks Identified. You may state that another spike is required for
+the team to resolve new issues identified (or) indicate that this spike has increased the teams
+confidence in XYZ and should move on.\*
 
-- e.g. Recommendation X:
-**
+- e.g. Recommendation X: \*\*

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,4 +1,4 @@
-Spike Outcomes
+# Spike Outcomes
 ==================
 **Spike:** Spike_No
 

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -2,11 +2,11 @@
 
 ==================
 
-## **Spike:** Spike_No
+**Spike:** Spike_No
 
-## **Title:** Spike_Title
+**Title:** Spike_Title
 
-## **Author:** John Doe, john.doe@example.com
+**Author:** John Doe, john.doe@example.com
 
 ## Goals / Deliverables
 
@@ -30,26 +30,26 @@ List of information needed by someone trying to reproduce this work\_
 
 ## Tasks undertaken
 
-### List key tasks likely to help another developer
+List key tasks likely to help another developer
 
 - ...
 
 ## What we found out
 
-### Describe (sentences), + graphs/screenshots/outcomes as needed
+Describe (sentences), + graphs/screenshots/outcomes as needed
 
 ## Open issues/risks *[Optional – remove heading/section if not used!]*
 
-*#### List out the issues and risks that you have been unable to resolve at the
- end of the spike. You may have uncovered a whole range of new risks as well.
- Make notes to help the team manage and respond.*
+List out the issues and risks that you have been unable to resolve at the
+end of the spike. You may have uncovered a whole range of new risks as well.
+Make notes to help the team manage and respond.*
 
 - e.g. Risk xyz (new)
 
 ## Recommendations *[Optional – remove heading/section if not used!]*
 
-*### Often based on any open issues/risks Identified. You may state that another
- spike is required for the team to resolve new issues identified (or) indicate
- that this spike has increased the teams confidence in XYZ and should move on.*
+Often based on any open issues/risks Identified. You may state that another
+spike is required for the team to resolve new issues identified (or) indicate
+that this spike has increased the teams confidence in XYZ and should move on.*
 
 - e.g. Recommendation X:

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,0 +1,44 @@
+Spike Outcomes
+==================
+**Spike:** Spike_No
+
+**Title:** Spike_Title
+
+**Author:** John Doe, john.doe@example.com
+
+## Goals / Deliverables:
+_#### Summarise from the spike plan goal_
+_#### Besides this report, what else was created ie UML, code, reports_
+- Code see /spikes/spike04/
+- Short Report titled “IDE Comparison”
+- …
+
+## Technologies, Tools, and Resources used:
+_#### List of information needed by someone trying to reproduce this work_
+- Internet Browser; Google Chrome, FireFox, Safari
+- Programming Languages:
+  - Ruby
+- Programming Libraries:
+  - Minitest
+- Text Editor: VsCode
+- Terminal
+
+## Tasks undertaken:
+#### List key tasks likely to help another developer
+- ...
+
+## What we found out:
+#### Describe (sentences), + graphs/screenshots/outcomes as needed
+
+
+## Open issues/risks _[Optional – remove heading/section if not used!]_:
+_#### List out the issues and risks that you have been unable to resolve at the
+ end of the spike. You may have uncovered a whole range of new risks as well.
+ Make notes to help the team manage and respond._
+- e.g. Risk xyz (new)
+
+## Recommendations _[Optional – remove heading/section if not used!]_:
+_### Often based on any open issues/risks Identified. You may state that another
+ spike is required for the team to resolve new issues identified (or) indicate
+ that this spike has increased the teams confidence in XYZ and should move on._
+- e.g. Recommendation X:

--- a/docs/Templates/SpikeOutcome-Template.md
+++ b/docs/Templates/SpikeOutcome-Template.md
@@ -1,4 +1,5 @@
 # Spike Outcomes
+
 ==================
 **Spike:** Spike_No
 
@@ -6,15 +7,19 @@
 
 **Author:** John Doe, john.doe@example.com
 
-## Goals / Deliverables:
+## Goals / Deliverables
+
 _#### Summarise from the spike plan goal_
 _#### Besides this report, what else was created ie UML, code, reports_
+
 - Code see /spikes/spike04/
 - Short Report titled “IDE Comparison”
 - …
 
-## Technologies, Tools, and Resources used:
+## Technologies, Tools, and Resources used
+
 _#### List of information needed by someone trying to reproduce this work_
+
 - Internet Browser; Google Chrome, FireFox, Safari
 - Programming Languages:
   - Ruby
@@ -23,22 +28,28 @@ _#### List of information needed by someone trying to reproduce this work_
 - Text Editor: VsCode
 - Terminal
 
-## Tasks undertaken:
+## Tasks undertaken
+
 #### List key tasks likely to help another developer
+
 - ...
 
-## What we found out:
+## What we found out
+
 #### Describe (sentences), + graphs/screenshots/outcomes as needed
 
+## Open issues/risks _[Optional – remove heading/section if not used!]_
 
-## Open issues/risks _[Optional – remove heading/section if not used!]_:
 _#### List out the issues and risks that you have been unable to resolve at the
  end of the spike. You may have uncovered a whole range of new risks as well.
  Make notes to help the team manage and respond._
+
 - e.g. Risk xyz (new)
 
-## Recommendations _[Optional – remove heading/section if not used!]_:
+## Recommendations _[Optional – remove heading/section if not used!]_
+
 _### Often based on any open issues/risks Identified. You may state that another
  spike is required for the team to resolve new issues identified (or) indicate
  that this spike has increased the teams confidence in XYZ and should move on._
+
 - e.g. Recommendation X:

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -2,7 +2,7 @@
 
 ==============
 
-## **Name:**
+**Name:**
 
 ## Context
 
@@ -10,11 +10,11 @@ Outline the reason and context for the spike.
 
 Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new Feature.
 
-## **Knowledge Gap:**
+**Knowledge Gap:**
 
-## **Skill Gap:**
+**Skill Gap:**
 
-## **Technology Gap:**
+**Technology Gap:**
 
 Provide details of the appropriate gaps related to this spike.
 

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,7 +1,8 @@
 # Spike Plan
 
 ==============
-**Name**:
+
+## **Name:**
 
 ## Context
 
@@ -9,11 +10,11 @@ Outline the reason and context for the spike.
 
 Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new Feature.
 
-**Knowledge Gap:**
+## **Knowledge Gap:**
 
-**Skill Gap:**
+## **Skill Gap:**
 
-**Technology Gap:**
+## **Technology Gap:**
 
 Provide details of the appropriate gaps related to this spike.
 

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,8 +1,10 @@
 # Spike Plan
+
 ==============
 **Name**:
 
-## Context:
+## Context
+
 Outline the reason and context for the spike.
 
 Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new Feature.
@@ -17,21 +19,24 @@ Provide details of the appropriate gaps related to this spike.
 
 Example: The Team is not familar with Data Analytics Aglorthms and needs to investigate further.
 
-## Goals/Deliverables:
+## Goals/Deliverables
+
 What are the goals and deliverables of this spike?
 Example:
+
 - Test out 3 different Aglorithms that can be used
 - Report on each Algorithms pros and cons.
-
 
 **Planned start date:**  Example: Week 6 T1 2023
 
 **Deadline:**  Week 7 T1 2023
 
-## Planning notes:
+## Planning notes
+
 Outline a proposed plan of how this spike can be undertaken.
 
 Example:
+
 - Write and test Algorithm a, write a report on its bennifits.
 - Review a Angular Component ahead of an upgrade
 - Create scripts to construct the database tables

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,4 +1,4 @@
-Spike Plan
+# Spike Plan
 ==============
 **Name**:
 

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,4 +1,4 @@
-# **Spike Plan
+# \*\*Spike Plan
 
 ==============
 
@@ -8,7 +8,8 @@
 
 Outline the reason and context for the spike.
 
-Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new Feature.
+Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new
+Feature.
 
 **Knowledge Gap:**
 
@@ -22,15 +23,14 @@ Example: The Team is not familar with Data Analytics Aglorthms and needs to inve
 
 ## Goals/Deliverables
 
-What are the goals and deliverables of this spike?
-Example:
+What are the goals and deliverables of this spike? Example:
 
 - Test out 3 different Aglorithms that can be used
 - Report on each Algorithms pros and cons.
 
-**Planned start date:**  Example: Week 6 T1 2023
+**Planned start date:** Example: Week 6 T1 2023
 
-**Deadline:**  Week 7 T1 2023
+**Deadline:** Week 7 T1 2023
 
 ## Planning notes
 

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,4 +1,4 @@
-# Spike Plan
+# **Spike Plan
 
 ==============
 

--- a/docs/Templates/SpikePlan-Template.md
+++ b/docs/Templates/SpikePlan-Template.md
@@ -1,0 +1,39 @@
+Spike Plan
+==============
+**Name**:
+
+## Context:
+Outline the reason and context for the spike.
+
+Example: Team needs to make a decision on the best type of Data Analytics Algorithm for the new Feature.
+
+**Knowledge Gap:**
+
+**Skill Gap:**
+
+**Technology Gap:**
+
+Provide details of the appropriate gaps related to this spike.
+
+Example: The Team is not familar with Data Analytics Aglorthms and needs to investigate further.
+
+## Goals/Deliverables:
+What are the goals and deliverables of this spike?
+Example:
+- Test out 3 different Aglorithms that can be used
+- Report on each Algorithms pros and cons.
+
+
+**Planned start date:**  Example: Week 6 T1 2023
+
+**Deadline:**  Week 7 T1 2023
+
+## Planning notes:
+Outline a proposed plan of how this spike can be undertaken.
+
+Example:
+- Write and test Algorithm a, write a report on its bennifits.
+- Review a Angular Component ahead of an upgrade
+- Create scripts to construct the database tables
+- Create scripts to populate the database tables with initial test data
+- Create scripts to tear down database


### PR DESCRIPTION
Added the Spike Plan template and Spike Outcome Template Daniel Maddern

# Description
Added 2 document templates to introduce Spikes in to the Thoth tech work flow.

## Type of change

- [X] Documentation (update or new)

# How Has This Been Tested?

Prettier and Vale checks.

## Testing Checklist:

- [X] Tested in latest Chrome

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation

