### PR TITLE
docs:DreamBig APi Documentation

### DIFF
--- a/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Category_questions_api.rb.md
+++ b/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Category_questions_api.rb.md
@@ -1,6 +1,7 @@
 # Documentation - category_questions_api.rb
 
-Github Link- [category_questions_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/category_questions_api.rb)
+Github Link-
+[category_questions_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/category_questions_api.rb)
 
 **Requires [Grape Framework](https://github.com/ruby-grape/grape#what-is-grape)**
 
@@ -14,7 +15,9 @@ Github Link- [category_questions_api.rb](https://github.com/thoth-tech/dream-big
 
 **Code does not perform validation currently, or anything relatively complex.**
 
-**The category question service is partially implemented in the frontend with a created service, but no data is being sent to the backend. This file is found in [category_question.service.ts](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-ui/src/app/services/category_question.service.ts#L16)**
+**The category question service is partially implemented in the frontend with a created service, but
+no data is being sent to the backend. This file is found in
+[category_question.service.ts](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-ui/src/app/services/category_question.service.ts#L16)**
 
 Future updates could include:
 
@@ -35,7 +38,8 @@ class CategoryQuestionsApi < Grape::API
   end
 ```
 
-Uses category questions ID as a parameter within variable 'category questions', where if it exists, it is presented to user using CategoryQuestionsEntity class.
+Uses category questions ID as a parameter within variable 'category questions', where if it exists,
+it is presented to user using CategoryQuestionsEntity class.
 
 ### Creation of category questions
 
@@ -69,9 +73,14 @@ This method requires a three parameter:
 - description
 - category_id
 
-Used within variable 'created_category_questions' to create an category questions, variable is presented to user via ['CategoryQuestionsEntity'](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/entities/category_questions_entity.rb#L2) class.
+Used within variable 'created_category_questions' to create an category questions, variable is
+presented to user via
+['CategoryQuestionsEntity'](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/entities/category_questions_entity.rb#L2)
+class.
 
-These parameters are used to create a question for the related category(unit/subject) which a student will need to answer within their assessments. The parameter 'category_id' is related to API file:
+These parameters are used to create a question for the related category(unit/subject) which a
+student will need to answer within their assessments. The parameter 'category_id' is related to API
+file:
 
 - [category_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/category_api.rb)
 
@@ -105,14 +114,16 @@ This method updates an existing category questions, requiring one variable as ne
 
 - id
 
- Two variable as optional:
+Two variable as optional:
 
 - description
 - category_id
 
 Parameters are placed within variable 'category_questions_parameters'.
 
-Within variable 'update_category_question' using 'CategoryQuestion' class find function with category questions ID, it updates an existing category question using values within 'category_questions_parameters'. This is presented to user via 'CategoryQuestionsEntity' class.
+Within variable 'update_category_question' using 'CategoryQuestion' class find function with
+category questions ID, it updates an existing category question using values within
+'category_questions_parameters'. This is presented to user via 'CategoryQuestionsEntity' class.
 
 ### Delete category questions with indicated ID
 
@@ -127,7 +138,8 @@ desc 'Delete the Category Question with the indicated id'
   end
 ```
 
-This method requires an category questions ID as a parameter. Should the category questions be found, it is deleted using 'CategoryQuestion' class' destroy function.
+This method requires an category questions ID as a parameter. Should the category questions be
+found, it is deleted using 'CategoryQuestion' class' destroy function.
 
 ### Get all categories
 
@@ -141,6 +153,7 @@ desc 'Get all the catagory questions'
 end
 ```
 
-This method uses the 'CategoryQuestionsEntity' class' all function, which acts as a value within the variable 'categories' holding all existing category questions.
+This method uses the 'CategoryQuestionsEntity' class' all function, which acts as a value within the
+variable 'categories' holding all existing category questions.
 
 This is presented to the user via 'CategoryQuestionsEntity' class.

--- a/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Category_questions_api.rb.md
+++ b/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Category_questions_api.rb.md
@@ -1,0 +1,146 @@
+# Documentation - category_questions_api.rb
+
+Github Link- [category_questions_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/category_questions_api.rb)
+
+**Requires [Grape Framework](https://github.com/ruby-grape/grape#what-is-grape)**
+
+## Code performs the following
+
+1. Retrieval of category questions
+2. Creation of category questions
+3. Update category questions
+4. Delete category questions with indicated ID
+5. Get all categorie questions
+
+**Code does not perform validation currently, or anything relatively complex.**
+
+**The category question service is partially implemented in the frontend with a created service, but no data is being sent to the backend. This file is found in [category_question.service.ts](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-ui/src/app/services/category_question.service.ts#L16)**
+
+Future updates could include:
+
+- Boolean checks
+- More detail about methods
+- Bug in delete section, should be 'return true' line 123
+
+### Retrieval of category questions
+
+```ruby
+class CategoryQuestionsApi < Grape::API
+  desc 'Allow retrieval of an Answer in the Assessment'
+  get '/category-questions/:id' do
+    # Auth
+
+    question = CategoryQuestion.find(params[:id])
+    present question, with: Entities::CategoryQuestionsEntity
+  end
+```
+
+Uses category questions ID as a parameter within variable 'category questions', where if it exists, it is presented to user using CategoryQuestionsEntity class.
+
+### Creation of category questions
+
+```ruby
+desc 'Allow creation of a Category Question'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+    requires :question, type: String, desc: 'question text'
+    requires :category_id, type: Integer, desc: 'category ID'
+  end
+  post '/category-questions' do
+    category_questions_parameters = ActionController::Parameters
+        .new(params)
+        .permit(
+          :id,
+          :question,
+          :category_id
+        )
+
+    # Auth...
+
+    created_category_question = CategoryQuestion.create!(category_questions_parameters)
+
+    present created_category_question, with: Entities::CategoryQuestionsEntity
+  end
+```
+
+This method requires a three parameter:
+
+- id
+- description
+- category_id
+
+Used within variable 'created_category_questions' to create an category questions, variable is presented to user via ['CategoryQuestionsEntity'](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/entities/category_questions_entity.rb#L2) class.
+
+These parameters are used to create a question for the related category(unit/subject) which a student will need to answer within their assessments. The parameter 'category_id' is related to API file:
+
+- [category_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/category_api.rb)
+
+### Update category questions
+
+```ruby
+desc 'Allow updating a Category Question'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+    optional :question, type: String, desc: 'question text'
+    optional :category_id, type: Integer, desc: 'category ID'
+  end
+  put '/category-questions/:id' do
+    category_questions_parameters = ActionController::Parameters
+        .new(params)
+        .permit(
+          :question,
+          :category_id,
+        )
+
+    # Auth
+
+    update_category_question = CategoryQuestion.find(params[:id])
+    update_category_question.update!(category_questions_parameters)
+
+    present update_category_question, with: Entities::CategoryQuestionsEntity
+  end
+```
+
+This method updates an existing category questions, requiring one variable as necessary:
+
+- id
+
+ Two variable as optional:
+
+- description
+- category_id
+
+Parameters are placed within variable 'category_questions_parameters'.
+
+Within variable 'update_category_question' using 'CategoryQuestion' class find function with category questions ID, it updates an existing category question using values within 'category_questions_parameters'. This is presented to user via 'CategoryQuestionsEntity' class.
+
+### Delete category questions with indicated ID
+
+```ruby
+desc 'Delete the Category Question with the indicated id'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+  end
+  delete '/category-questions/:id' do
+    CategoryQuestion.find(params[:id]).destroy!
+    true
+  end
+```
+
+This method requires an category questions ID as a parameter. Should the category questions be found, it is deleted using 'CategoryQuestion' class' destroy function.
+
+### Get all categories
+
+```ruby
+desc 'Get all the catagory questions'
+  get '/category-questions' do
+    catagory_questions = CategoryQuestion.all
+
+    present catagory_questions, with: Entities::CategoryQuestionsEntity
+  end
+end
+```
+
+This method uses the 'CategoryQuestionsEntity' class' all function, which acts as a value within the variable 'categories' holding all existing category questions.
+
+This is presented to the user via 'CategoryQuestionsEntity' class.

--- a/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Dream_big_api.rb.md
+++ b/docs/DreamBig/Documentation & QA/2023_T1_API/DreamBig Markdown Dream_big_api.rb.md
@@ -1,0 +1,120 @@
+# Documentation - dream_big_api.rb
+
+Github Link-
+[dream_big_api.rb](https://github.com/thoth-tech/dream-big/blob/d72249d788068c71962e5a760ab1e15caef50ce5/dream-big-api/app/api/dream_big_api.rb)
+
+**Requires:**
+
+- **[Grape Framework](https://github.com/ruby-grape/grape#what-is-grape)**
+- **[Grape-Swagger](https://github.com/ruby-grape/grape-swagger)**
+
+The file is in **JSON** format
+
+```JSON
+class DreamBigApi < Grape::API
+  prefix "api"
+  format :json
+
+  before do
+    headers["Access-Control-Allow-Origin"] = "*"
+    headers["Access-Control-Allow-Methods"] = "POST, PUT, DELETE, GET, OPTIONS"
+    headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  end
+
+  rescue_from :all do |e|
+    case e
+    when ActiveRecord::RecordInvalid, Grape::Exceptions::ValidationErrors
+      message = e.message
+      status = 400
+    when ActiveRecord::InvalidForeignKey
+      message = "This operation has been rejected as it would break data integrity. Ensure that related values are deleted or updated before trying again."
+      status = 400
+    when Grape::Exceptions::MethodNotAllowed
+      message = e.message
+      status = 405
+    when ActiveRecord::RecordNotDestroyed
+      message = e.message
+      status = 400
+    when ActiveRecord::RecordNotFound
+      message = "Unable to find requested #{e.message[/(Couldn't find )(.*)( with)/, 2]}"
+      status = 404
+    else
+      # logger.error "Unhandled exception: #{e.class}"
+      # logger.error e.inspect
+      # logger.error e.backtrace.join("\n")
+
+      puts "FAILING!"
+      puts e.inspect
+      puts e.backtrace.join("\n")
+
+      message = "Sorry... something went wrong with your request."
+      message = e.inspect
+      status = 500
+    end
+    Rack::Response.new({ error: message }.to_json, status, { "Content-type" => "text/error" })
+  end
+```
+
+The above headers are run before the main block of code.
+
+the 'rescue_from' method checks for exceptions **'|e|'** from the entire code using case statements.
+Should errors occur, it will match with a case and an error is thrown along with setting a status,
+such as:
+
+- **status=400** [Bad Request]
+- **status=404** [ API user not found]
+- **status=405** [ HTTP request not allowed]
+
+Error is displayed for user in quotes, such as:
+
+> "Unable to find requested #{e.message[/(Couldn't find )(.*)( with)/, 2]}"
+
+Backtrace associated with exception where it is located is an array of strings. It will then output
+a user written message and output a error:
+
+- **status=500** [HTTP internal server ]
+
+This is done with a message as seen in line 44:
+
+> Rack::Response.new({ error: message }.to_json, status, { "Content-type" => "text/error" }
+
+---
+
+```JSON
+#mount DreamBigApi
+  mount CategoryApi
+  mount UsersApi
+  mount StudentApi
+  mount AvatarApi
+  mount AvatarHairsApi
+  mount AvatarHeadsApi
+  mount AvatarAccessoriesApi
+  mount AvatarTorsosApi
+  mount AnswersApi
+  mount AssessmentsApi
+  mount CategoryQuestionsApi
+  mount JourneysApi
+  mount PlanetsApi
+  mount SectionsApi
+  mount GoalsApi
+  mount ReflectionsApi
+  mount PlansApi
+
+  add_swagger_documentation(
+    base_path: nil,
+    api_version: "v1",
+    hide_documentation_path: true,
+    info: {
+      title: "Dream-big-api API Documentaion",
+      description: "Dreambig-api is an entity service and web socket proof of concept.",
+      license: "AGPL v3.0",
+      license_url: "https://github.com/doubtfire-lms/dream-big/blob/main/LICENSE",
+    },
+    mount_path: "swagger_doc"
+  )
+end
+```
+
+The rest of the code is mounting all API files within
+**['API'](https://github.com/codeJdawg/dream-big-api-documentation/tree/main/dream-big-api/app/api)**
+directory.


### PR DESCRIPTION
This is documentation of the main DreamBig API file, how it is related to all other existing API files, and related frontend services.

JadenDMD@Gmail.com

# Description

This is documentation of the Main API file DreamBig.

## Type of change

- [X ] Documentation (update or new)

# How Has This Been Tested?

This is documentation, no testing is required.

# Checklist:

- [X ] I have made corresponding changes to the documentation
