### PR TITLE
Cleanup build instructions

### DIFF
--- a/docs/Splashkit/Applications/Arcade Machines/Arcade Machine Setup/Setup Arcade Machine.md
+++ b/docs/Splashkit/Applications/Arcade Machines/Arcade Machine Setup/Setup Arcade Machine.md
@@ -2,8 +2,7 @@
 
 ## Existing Image
 
-Download current arcade Image from here (accessible to Thoth-Tech Team Members):
-<https://deakin365.sharepoint.com/:u:/r/sites/ThothTech2/Shared%20Documents/SplashKit/Arcade%20Machine%20Image/ArcadeMachine.img?csf=1&web=1&e=7cuS7Z>
+Download current arcade Image from here (accessible to Thoth-Tech Team Members): [here](https://deakin365.sharepoint.com/:u:/r/sites/ThothTech2/Shared%20Documents/SplashKit/Arcade%20Machine%20Image/ArcadeMachine.img?csf=1&web=1&e=7cuS7Z)
 
 SHA256 Hash `31f0ea11c8492000d003108bf84afbb261ad6ee7c1be989f52a2b4add9d8821e`
 
@@ -111,7 +110,7 @@ and one to wpa_supplicant:
 
 ### 1. Install SplashKit
 
-- Follow the instructions [here](https://splashkit.io/articles/installation/ubuntu/).
+- Follow the instructions [here](https://splashkit.io/installation/linux/).
 - Primarly perform steps 1 and 2, VS code is optional unless you whish to adjust programming on the
   PI directly.
 
@@ -126,19 +125,27 @@ and one to wpa_supplicant:
      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel STS
      ```
 
-  2. Add the following to the end of the file `~/.bashrc` with these commands
+  1. Add the following to the end of the file `~/.bashrc` with these commands
 
      ```shell
      echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
      echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
+     echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bash.bash_profile
+     echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bash_profile
      source ~/.bashrc
      ```
 
-  3. Verify the insalation with this command
+  1. Verify the insalation with this command
 
      ```shell
      dotnet --version
      ```
+
+   1. Create dotnet symbolic link. Replace `<VERSION>` with your dotnet version e.g. 7.0.5 
+
+      ```shell
+      ln -s ~/.splashkit/lib/linux/libsplashkit.so ~/.dotnet/shared/Microsoft.NetCore.App/<VERSION>/      
+      ```
 
 ### 3. Install Git
 
@@ -183,7 +190,7 @@ and one to wpa_supplicant:
    nano ~/.emulationstation/es_systems.cfg
    ```
 
-8. Add the following to the file or downlaod a copy from
+8. Add the following to the file or download a copy from
    [here](/docs/Splashkit/Applications/Arcade%20Machines/Arcade%20Machine%20Setup/Files/es_systems.cfg)
 
    ```config
@@ -295,7 +302,7 @@ and one to wpa_supplicant:
 
 4. Select Console Autologin
 
-   ![Rasberry Pi Boot Option Screen](/docs/Splashkit/Applications/Arcade%20Machines/Arcade%20Machine%20Setup/Images/ConsoleAutoLogin.png)
+   ![Rasberry Pi system Option Screen](/docs/Splashkit/Applications/Arcade%20Machines/Arcade%20Machine%20Setup/Images/ConsoleAutologin.png)
 
 5. Return to main menu
 6. Select Advanced Options


### PR DESCRIPTION
# Description
Previous build instructions would not link dotnet library if the  arcade machine was configured without a desktop environment.  In a desktop-less environment ~/.bashrc is not loaded but ~/.bash.bash_profile is. This fixes this problem too.

The old .md file explicitly numbers points rather than using  `1., 1.,1.`  to generate them automatically. This is a problem in this doc generally, but I will split that amendment into a separate pull if it's deemed an issue. 

**update
The arcade cabinet build instructions direct users to a broken link on the Splashkit.io docs site.
The URL points to "https://splashkit.io/articles/installation/ubuntu/"

But this page as changed to https://splashkit.io/installation/linux/ at some point. It's possible to navigate to the correct page from the 404 in a couple of clicks, but there's no reason not to update this URL to point to the correct place.

Also replaced an ugly full link to sharepoint with an embedded link for better readability.

There's also a broken image in the "Configure Start CLI on Boot and Network Manager" section that pointed to a typo'd file that i have corrected.

The other links seem to be free from link rot.

## Type of change
- [X] Documentation (update or new)

# How Has This Been Tested?
.md file has been tested locally to ensure formatting is consistent and remains unbroken. 

## Testing Checklist:
- [X] Tested in latest Firefox

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
