### PR TITLE
Add tutorial section documentation

### DIFF
--- a/docs/Splashkit/Tutorials/Reviews/README.md
+++ b/docs/Splashkit/Tutorials/Reviews/README.md
@@ -1,0 +1,11 @@
+# Place your tutorials review within this folder
+
+When doing a tutorial review ensure to do the following:
+
+- Proof read the tutorial to make sure there are no grammatical errors.
+- Ensure the tutorial has the following languages:
+  - C# using top level statements only
+  - C++ 
+  - Python
+- Run all the code in the way the tutorial describes to ensure it works.
+- Include screenshots of all the code running in your pull request description.

--- a/docs/Splashkit/Tutorials/Reviews/template.md
+++ b/docs/Splashkit/Tutorials/Reviews/template.md
@@ -12,7 +12,10 @@ This tutorial covers how to do this...
 
 - [ ] The tutorial is free of spelling and grammatical errors.
 - [ ] The tutorial is easy to follow.
-- [ ] The tutorial uses top level statements in C# and C++.
+- [ ] The tutorial has:
+  - [ ] C# using top level statements
+  - [ ] C++
+  - [ ] Python
 - [ ] The code passes all the Quality Checks.
 
 ## Links:

--- a/docs/Splashkit/Tutorials/Reviews/template.md
+++ b/docs/Splashkit/Tutorials/Reviews/template.md
@@ -1,0 +1,28 @@
+# Title
+
+Date Reviewed:
+Reviewed by: 
+
+## Description:
+
+This tutorial covers how to do this...
+
+
+## Confirmation of Passing Quality Checks:
+
+- [ ] The tutorial is free of spelling and grammatical errors.
+- [ ] The tutorial is easy to follow.
+- [ ] The tutorial uses top level statements in C# and C++.
+- [ ] The code passes all the Quality Checks.
+
+## Links:
+
+Website Link:
+
+Pull Request:
+
+## Improvements and suggestions:
+
+If you have any suggestions for improvements or changes, add here:
+
+- add here

--- a/docs/Splashkit/Tutorials/overview.md
+++ b/docs/Splashkit/Tutorials/overview.md
@@ -1,0 +1,5 @@
+# SplashKit Tutorials Team
+
+The SplashKit tutorials team is dedicated to creating high-quality tutorials that showcase the versatile functionality of the SplashKit library. Covering a broad range of topics such as Graphics, Interfaces, Networking, and Raspberry Pis, these tutorials are designed to equip users with the skills needed to develop their own projects. Each tutorial includes detailed explanations, step-by-step instructions, and code snippets in C#, C++, Python, and Pascal to cater to a diverse audience.
+
+The SplashKit website will feature these tutorials, with a focus on helping students learn and explore SplashKit’s capabilities. Emphasising smaller, high-quality tutorials across C++, C#, and Python, the aim is to provide concise, yet comprehensive learning resources rather than extensive series, ensuring that users can quickly grasp and apply the concepts in their own projects.


### PR DESCRIPTION
Added folder under splashkit for the tutorials team as well as the folder for the tutorial reviews.
Set up the template page for use when a tutorial has been reviewed.

The intention is that once a tutorial has been reviewed, the reviewer will create a page within the Tutorial review folder to add the information about that tutorial using the provided template.